### PR TITLE
feat(alert): add alert service

### DIFF
--- a/services/alert-service/Dockerfile
+++ b/services/alert-service/Dockerfile
@@ -1,0 +1,16 @@
+FROM maven:3.9-eclipse-temurin-17 AS builder
+WORKDIR /app
+COPY pom.xml .
+RUN mvn dependency:go-offline -B
+COPY src ./src
+RUN mvn clean package -DskipTests
+
+FROM eclipse-temurin:17-jre-alpine
+RUN addgroup -S spring && adduser -S spring -G spring
+USER spring:spring
+WORKDIR /app
+COPY --from=builder /app/target/alert-service.jar app.jar
+EXPOSE 8083
+HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
+    CMD wget --quiet --tries=1 --spider http://localhost:8083/actuator/health || exit 1
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/services/alert-service/pom.xml
+++ b/services/alert-service/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.fraud</groupId>
+    <artifactId>alert-service</artifactId>
+    <version>1.0.0</version>
+    <name>Alert Service</name>
+    <description>Alert management service - consumes fraud alerts and exposes via WebSocket</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.0</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Kafka -->
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+
+        <!-- WebSocket -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-websocket</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+        <finalName>alert-service</finalName>
+    </build>
+</project>

--- a/services/alert-service/src/main/java/com/fraud/alert/AlertServiceApplication.java
+++ b/services/alert-service/src/main/java/com/fraud/alert/AlertServiceApplication.java
@@ -1,0 +1,25 @@
+package com.fraud.alert;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.kafka.annotation.EnableKafka;
+
+@SpringBootApplication
+@EnableKafka
+public class AlertServiceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(AlertServiceApplication.java, args);
+
+        System.out.println("""
+
+                ============================================
+                🚨  ALERT SERVICE STARTED
+                ============================================
+                Port: 8083
+                Kafka Consumer: fraud-alerts-topic
+                REST API: /api/alerts
+                ============================================
+                """);
+    }
+}

--- a/services/alert-service/src/main/java/com/fraud/alert/controller/AlertController.java
+++ b/services/alert-service/src/main/java/com/fraud/alert/controller/AlertController.java
@@ -1,0 +1,47 @@
+package com.fraud.alert.controller;
+
+import com.fraud.alert.model.Alert;
+import com.fraud.alert.service.AlertService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/alerts")
+public class AlertController {
+
+    private final AlertService alertService;
+
+    public AlertController(AlertService alertService) {
+        this.alertService = alertService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<Alert>> getAllAlerts() {
+        return ResponseEntity.ok(alertService.getAllAlerts());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Alert> getAlertById(@PathVariable Long id) {
+        return alertService.getAlertById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/status/{status}")
+    public ResponseEntity<List<Alert>> getAlertsByStatus(@PathVariable Alert.AlertStatus status) {
+        return ResponseEntity.ok(alertService.getAlertsByStatus(status));
+    }
+
+    @PatchMapping("/{id}/status")
+    public ResponseEntity<Alert> updateStatus(
+            @PathVariable Long id,
+            @RequestParam Alert.AlertStatus status,
+            @RequestParam(required = false) String reviewedBy,
+            @RequestParam(required = false) String notes) {
+
+        Alert updated = alertService.updateAlertStatus(id, status, reviewedBy, notes);
+        return ResponseEntity.ok(updated);
+    }
+}

--- a/services/alert-service/src/main/java/com/fraud/alert/kafka/AlertConsumer.java
+++ b/services/alert-service/src/main/java/com/fraud/alert/kafka/AlertConsumer.java
@@ -1,0 +1,49 @@
+package com.fraud.alert.kafka;
+
+import com.fraud.alert.model.Alert;
+import com.fraud.alert.service.AlertService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+@Component
+public class AlertConsumer {
+
+    private static final Logger logger = LoggerFactory.getLogger(AlertConsumer.class);
+    private final AlertService alertService;
+
+    public AlertConsumer(AlertService alertService) {
+        this.alertService = alertService;
+    }
+
+    @KafkaListener(
+            topics = "${fraud.kafka.topic.alerts}",
+            groupId = "${spring.kafka.consumer.group-id}"
+    )
+    public void consumeAlert(Map<String, Object> alertData) {
+        try {
+            logger.info("Received alert from Kafka: {}", alertData);
+
+            Alert alert = new Alert();
+            alert.setTransactionId((String) alertData.get("transaction_id"));
+
+            Object riskScoreObj = alertData.get("risk_score");
+            if (riskScoreObj instanceof Number) {
+                alert.setRiskScore(BigDecimal.valueOf(((Number) riskScoreObj).doubleValue()));
+            }
+
+            alert.setAlertData(alertData);
+
+            alertService.createAlert(alert);
+
+            logger.info("Alert saved successfully: {}", alert.getTransactionId());
+
+        } catch (Exception e) {
+            logger.error("Error processing alert: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/services/alert-service/src/main/java/com/fraud/alert/model/Alert.java
+++ b/services/alert-service/src/main/java/com/fraud/alert/model/Alert.java
@@ -1,0 +1,62 @@
+package com.fraud.alert.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Entity
+@Table(name = "alerts")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Alert {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "transaction_id", nullable = false)
+    private String transactionId;
+
+    @Column(name = "risk_score", nullable = false)
+    private BigDecimal riskScore;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20)
+    private AlertStatus status = AlertStatus.NEW;
+
+    @Column(name = "reviewed_by", length = 100)
+    private String reviewedBy;
+
+    @Column(name = "reviewed_at")
+    private LocalDateTime reviewedAt;
+
+    @Column(name = "notes", columnDefinition = "TEXT")
+    private String notes;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "alert_data", columnDefinition = "jsonb")
+    private Map<String, Object> alertData;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+
+    public enum AlertStatus {
+        NEW,
+        REVIEWED,
+        CONFIRMED_FRAUD,
+        FALSE_POSITIVE
+    }
+}

--- a/services/alert-service/src/main/java/com/fraud/alert/repository/AlertRepository.java
+++ b/services/alert-service/src/main/java/com/fraud/alert/repository/AlertRepository.java
@@ -1,0 +1,13 @@
+package com.fraud.alert.repository;
+
+import com.fraud.alert.model.Alert;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface AlertRepository extends JpaRepository<Alert, Long> {
+    List<Alert> findByStatus(Alert.AlertStatus status);
+    List<Alert> findByTransactionId(String transactionId);
+}

--- a/services/alert-service/src/main/java/com/fraud/alert/service/AlertService.java
+++ b/services/alert-service/src/main/java/com/fraud/alert/service/AlertService.java
@@ -1,0 +1,58 @@
+package com.fraud.alert.service;
+
+import com.fraud.alert.model.Alert;
+import com.fraud.alert.repository.AlertRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class AlertService {
+
+    private static final Logger logger = LoggerFactory.getLogger(AlertService.class);
+    private final AlertRepository alertRepository;
+
+    public AlertService(AlertRepository alertRepository) {
+        this.alertRepository = alertRepository;
+    }
+
+    @Transactional
+    public Alert createAlert(Alert alert) {
+        logger.info("Creating alert: Transaction={}, RiskScore={}",
+                alert.getTransactionId(), alert.getRiskScore());
+
+        Alert savedAlert = alertRepository.save(alert);
+
+        logger.info("Alert created: ID={}", savedAlert.getId());
+        return savedAlert;
+    }
+
+    public List<Alert> getAllAlerts() {
+        return alertRepository.findAll();
+    }
+
+    public Optional<Alert> getAlertById(Long id) {
+        return alertRepository.findById(id);
+    }
+
+    public List<Alert> getAlertsByStatus(Alert.AlertStatus status) {
+        return alertRepository.findByStatus(status);
+    }
+
+    @Transactional
+    public Alert updateAlertStatus(Long id, Alert.AlertStatus status, String reviewedBy, String notes) {
+        Alert alert = alertRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Alert not found: " + id));
+
+        alert.setStatus(status);
+        alert.setReviewedBy(reviewedBy);
+        alert.setNotes(notes);
+        alert.setReviewedAt(java.time.LocalDateTime.now());
+
+        return alertRepository.save(alert);
+    }
+}

--- a/services/alert-service/src/main/resources/application-docker.yml
+++ b/services/alert-service/src/main/resources/application-docker.yml
@@ -1,0 +1,8 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://postgres:5432/fraud_db
+    username: ${POSTGRES_USER}
+    password: ${POSTGRES_PASSWORD}
+
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}

--- a/services/alert-service/src/main/resources/application.yml
+++ b/services/alert-service/src/main/resources/application.yml
@@ -1,0 +1,43 @@
+server:
+  port: 8083
+
+spring:
+  application:
+    name: alert-service
+
+  datasource:
+    url: jdbc:postgresql://localhost:5432/fraud_db
+    username: fraud_user
+    password: fraud_pass_2025
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: none
+    show-sql: true
+
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: alert-service-group
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.trusted.packages: "com.fraud.*"
+
+fraud:
+  kafka:
+    topic:
+      alerts: fraud-alerts-topic
+
+logging:
+  level:
+    root: INFO
+    com.fraud.alert: DEBUG
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics


### PR DESCRIPTION
Consume fraud alerts from Kafka, persist to DB, expose REST API.

- Port: 8083
- Consumer group: alert-service-group
- Status: NEW, REVIEWED, CONFIRMED_FRAUD, FALSE_POSITIVE

Closes #1